### PR TITLE
🐛  fix rendering of unicode emojis in the place of the name tag

### DIFF
--- a/qalib/translators/message_parsing.py
+++ b/qalib/translators/message_parsing.py
@@ -214,6 +214,9 @@ def make_emoji(raw_emoji: Optional[Union[str, Emoji]]) -> Optional[str]:
     if "name" not in raw_emoji:
         raise ValueError("Missing Emoji Name")
 
+    if emoji.is_emoji(raw_emoji["name"]):
+        return raw_emoji["name"]
+
     if "id" not in raw_emoji:
         return emoji.emojize(":" + raw_emoji["name"] + ":")
 


### PR DESCRIPTION
fixes #129 
version: patch

allow rendering of emojis such as ✅ by just using the unicode emoji rather than name