### PR TITLE
✨ Add Strip Attribute to xml content

### DIFF
--- a/qalib/translators/xml.py
+++ b/qalib/translators/xml.py
@@ -207,8 +207,7 @@ class XMLDeserializer(Deserializer[K_contra]):
                 lambda raw_tree: list(map(self._render_embed, raw_tree)),
             ),
             view=apply(get_element(message_tree, "view"), self._render_view, callables, events),
-            content="".join(get_text(message_tree, "content").split()) if (content := get_element("content")) \ 
-                    and get_attribute(content, "strip") == "true" else get_text(message_tree, "content"),
+            content="".join(get_text(message_tree, "content").split()) if (content := get_element("content")) and get_attribute(content, "strip") == "true" else get_text(message_tree, "content"),
             tts=apply(get_text(message_tree, "tts"), lambda string: string.lower() == "true"),
             nonce=apply(get_text(message_tree, "nonce"), int),
             delete_after=apply(get_text(message_tree, "delete_after"), float),

--- a/qalib/translators/xml.py
+++ b/qalib/translators/xml.py
@@ -207,7 +207,10 @@ class XMLDeserializer(Deserializer[K_contra]):
                 lambda raw_tree: list(map(self._render_embed, raw_tree)),
             ),
             view=apply(get_element(message_tree, "view"), self._render_view, callables, events),
-            content="".join(get_text(message_tree, "content").split()) if (content := get_element("content")) and get_attribute(content, "strip") == "true" else get_text(message_tree, "content"),
+            content="".join(get_text(message_tree, "content").split()) 
+            if (content := get_element(message_tree "content")) 
+            and get_attribute(content, "strip") == "true" 
+            else get_text(message_tree, "content"),
             tts=apply(get_text(message_tree, "tts"), lambda string: string.lower() == "true"),
             nonce=apply(get_text(message_tree, "nonce"), int),
             delete_after=apply(get_text(message_tree, "delete_after"), float),

--- a/qalib/translators/xml.py
+++ b/qalib/translators/xml.py
@@ -208,7 +208,7 @@ class XMLDeserializer(Deserializer[K_contra]):
             ),
             view=apply(get_element(message_tree, "view"), self._render_view, callables, events),
             content="".join(get_text(message_tree, "content").split()) 
-            if (content := get_element(message_tree "content")) 
+            if (content := get_element(message_tree, "content")) 
             and get_attribute(content, "strip") == "true" 
             else get_text(message_tree, "content"),
             tts=apply(get_text(message_tree, "tts"), lambda string: string.lower() == "true"),

--- a/qalib/translators/xml.py
+++ b/qalib/translators/xml.py
@@ -207,9 +207,9 @@ class XMLDeserializer(Deserializer[K_contra]):
                 lambda raw_tree: list(map(self._render_embed, raw_tree)),
             ),
             view=apply(get_element(message_tree, "view"), self._render_view, callables, events),
-            content="".join(get_text(message_tree, "content").split()) 
-            if (content := get_element(message_tree, "content")) 
-            and self.get_attribute(content, "strip") == "true" 
+            content=" ".join(get_text(message_tree, "content").split())
+            if (content := get_element(message_tree, "content"))
+            and self.get_attribute(content, "strip") == "true"
             else get_text(message_tree, "content"),
             tts=apply(get_text(message_tree, "tts"), lambda string: string.lower() == "true"),
             nonce=apply(get_text(message_tree, "nonce"), int),

--- a/qalib/translators/xml.py
+++ b/qalib/translators/xml.py
@@ -207,7 +207,8 @@ class XMLDeserializer(Deserializer[K_contra]):
                 lambda raw_tree: list(map(self._render_embed, raw_tree)),
             ),
             view=apply(get_element(message_tree, "view"), self._render_view, callables, events),
-            content=get_text(message_tree, "content"),
+            content="".join(get_text(message_tree, "content").split()) if (content := get_element("content")) \ 
+                    and get_attribute(content, "strip") == "true" else get_text(message_tree, "content"),
             tts=apply(get_text(message_tree, "tts"), lambda string: string.lower() == "true"),
             nonce=apply(get_text(message_tree, "nonce"), int),
             delete_after=apply(get_text(message_tree, "delete_after"), float),

--- a/qalib/translators/xml.py
+++ b/qalib/translators/xml.py
@@ -209,7 +209,7 @@ class XMLDeserializer(Deserializer[K_contra]):
             view=apply(get_element(message_tree, "view"), self._render_view, callables, events),
             content="".join(get_text(message_tree, "content").split()) 
             if (content := get_element(message_tree, "content")) 
-            and get_attribute(content, "strip") == "true" 
+            and self.get_attribute(content, "strip") == "true" 
             else get_text(message_tree, "content"),
             tts=apply(get_text(message_tree, "tts"), lambda string: string.lower() == "true"),
             nonce=apply(get_text(message_tree, "nonce"), int),


### PR DESCRIPTION
Adding strip attribute to remove excessive white space and tabs from the text in content
```xml
<discord>
    <message key="a">
        <content strip="true">
            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore 
            magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo 
            consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. 
            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
        </content>
    </message>
</discord>
``` 

version: patch

