### PR TITLE
✨ Allow for passing QalibInteractions into another QalibInteraction

### DIFF
--- a/.github/workflows/twine-publish.yml
+++ b/.github/workflows/twine-publish.yml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
           ref: ${{ github.ref }}
       - name: Bump and Publisher Distribution to PyPi
-        uses: YousefEZ/auto-pypi@0.0.13
+        uses: YousefEZ/auto-pypi@latest
         with:
           githubtoken: ${{ secrets.GITHUB_TOKEN }}
           twinetoken: ${{ secrets.TWINE_USERNAME }}

--- a/.github/workflows/twine-publish.yml
+++ b/.github/workflows/twine-publish.yml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
           ref: ${{ github.ref }}
       - name: Bump and Publisher Distribution to PyPi
-        uses: YousefEZ/auto-pypi@latest
+        uses: YousefEZ/auto-pypi@0.0.13
         with:
           githubtoken: ${{ secrets.GITHUB_TOKEN }}
           twinetoken: ${{ secrets.TWINE_USERNAME }}

--- a/qalib/__init__.py
+++ b/qalib/__init__.py
@@ -4,6 +4,7 @@ Extensions to the Rapptz Discord.py library, adding the use of templating on emb
 :copyright: (c) 2022-present YousefEZ
 :license: MIT, see LICENSE for more details.
 """
+
 from __future__ import annotations
 
 from functools import wraps
@@ -40,14 +41,20 @@ def qalib_context(
 
     Returns (QalibContext): decorated function that takes the Context object and using the extended QalibContext object
     """
-    renderer_instance: Renderer[str] = Renderer(template_engine, filename, *renderer_options)
+    renderer_instance: Renderer[str] = Renderer(
+        template_engine, filename, *renderer_options
+    )
 
     def command(func: Callable[..., Coro[T]]) -> Callable[..., Coro[T]]:
         if discord.utils.is_inside_class(func):
 
             @wraps(func)
-            async def method(self: commands.Cog, ctx: commands.Context, *args: Any, **kwargs: Any) -> T:
-                return await func(self, QalibContext(ctx, renderer_instance), *args, **kwargs)
+            async def method(
+                self: commands.Cog, ctx: commands.Context, *args: Any, **kwargs: Any
+            ) -> T:
+                return await func(
+                    self, QalibContext(ctx, renderer_instance), *args, **kwargs
+                )
 
             return method
 
@@ -74,7 +81,9 @@ def qalib_interaction(
     Returns (Callable): decorated function that takes the Interaction object and using the extended
     QalibInteraction object
     """
-    renderer_instance: Renderer[str] = Renderer(template_engine, filename, *renderer_options)
+    renderer_instance: Renderer[str] = Renderer(
+        template_engine, filename, *renderer_options
+    )
 
     def command(func: Callable[..., Coro[T]]) -> Callable[..., Coro[T]]:
         if discord.utils.is_inside_class(func):
@@ -82,17 +91,21 @@ def qalib_interaction(
             @wraps(func)
             async def method(
                 self: commands.Cog,
-                inter: discord.Interaction,
+                inter: discord.Interaction | QalibInteraction[Any],
                 *args: Any,
                 **kwargs: Any,
             ) -> T:
-                return await func(self, QalibInteraction(inter, renderer_instance), *args, **kwargs)
+                return await func(
+                    self, QalibInteraction(inter, renderer_instance), *args, **kwargs
+                )
 
             return method
 
         @wraps(func)
         async def function(inter: discord.Interaction, *args: Any, **kwargs: Any) -> T:
-            return await func(QalibInteraction(inter, renderer_instance), *args, **kwargs)
+            return await func(
+                QalibInteraction(inter, renderer_instance), *args, **kwargs
+            )
 
         return function
 
@@ -112,12 +125,18 @@ def qalib_item_interaction(
     Returns (Callable): decorated function that takes the Interaction object and using the extended
     QalibInteraction object
     """
-    renderer_instance: Renderer[str] = Renderer(template_engine, filename, *renderer_options)
+    renderer_instance: Renderer[str] = Renderer(
+        template_engine, filename, *renderer_options
+    )
 
     def command(func: Callable[..., Coro[T]]) -> Callable[..., Coro[T]]:
         @wraps(func)
-        async def function(item: discord.ui.Item, inter: discord.Interaction, *args: Any, **kwargs: Any) -> T:
-            return await func(item, QalibInteraction(inter, renderer_instance), *args, **kwargs)
+        async def function(
+            item: discord.ui.Item, inter: discord.Interaction, *args: Any, **kwargs: Any
+        ) -> T:
+            return await func(
+                item, QalibInteraction(inter, renderer_instance), *args, **kwargs
+            )
 
         return function
 

--- a/qalib/context.py
+++ b/qalib/context.py
@@ -15,7 +15,9 @@ from qalib.translators.menu import Menu
 class QalibContext(discord.ext.commands.context.Context, Generic[K_contra]):
     """QalibContext object is responsible for handling messages that are to be sent to the client."""
 
-    def __init__(self, ctx: discord.ext.commands.context.Context, renderer: Renderer[K_contra]):
+    def __init__(
+        self, ctx: discord.ext.commands.context.Context, renderer: Renderer[K_contra]
+    ):
         """Constructor for the QalibContext object
 
         Args:
@@ -51,11 +53,16 @@ class QalibContext(discord.ext.commands.context.Context, Generic[K_contra]):
         Returns:
             bool: true of false that indicates whether the data is valid.
         """
-        return message.author == self.message.author and message.channel == self.message.channel
+        return (
+            message.author == self.message.author
+            and message.channel == self.message.channel
+        )
 
     async def get_message(self) -> Optional[str]:
         """This method waits for a message to be sent by the user"""
-        confirm: Optional[discord.message.Message] = await self.bot.wait_for("message", timeout=59.0, check=self.verify)
+        confirm: Optional[discord.message.Message] = await self.bot.wait_for(
+            "message", timeout=59.0, check=self.verify
+        )
         return confirm.content if confirm is not None else None
 
     async def rendered_send(
@@ -85,7 +92,9 @@ class QalibContext(discord.ext.commands.context.Context, Generic[K_contra]):
             message = message.front
 
         assert isinstance(message, Message)
-        return await self.send(**{**message.convert_to_context_message().dict(), **kwargs})
+        return await self.send(
+            **{**message.convert_to_context_message().dict(), **kwargs}
+        )
 
     async def display(
         self,
@@ -114,7 +123,9 @@ class QalibContext(discord.ext.commands.context.Context, Generic[K_contra]):
 
         assert isinstance(message, Message)
         if self._displayed:
-            await self._display(**{**message.convert_to_context_message().as_edit().dict(), **kwargs})
+            await self._display(
+                **{**message.convert_to_context_message().as_edit().dict(), **kwargs}
+            )
             return
         await self._display(**{**message.convert_to_context_message().dict(), **kwargs})
 


### PR DESCRIPTION
This feature allows users to wrap QalibInteraction into another QalibInteraction which would be useful if they would like to use another renderer

version: patch