### PR TITLE
🐛 Fix display issues

### DIFF
--- a/qalib/interaction.py
+++ b/qalib/interaction.py
@@ -38,7 +38,7 @@ class QalibInteraction(discord.Interaction, Generic[K_contra]):
             else interaction
         )
         self._renderer = renderer
-        self._displayed = False
+        self._displayed = getattr(interaction, "_displayed", False)
 
     async def rendered_send(
         self,


### PR DESCRIPTION
When double wrapping a QalibInteraction, the display method would return to False even though it might have been displayed.

version: patch